### PR TITLE
fix(rk3576): disable GICV2_G0_FOR_EL3 when SPD is opteed

### DIFF
--- a/plat/rockchip/rk3576/platform.mk
+++ b/plat/rockchip/rk3576/platform.mk
@@ -104,7 +104,14 @@ ERRATA_A72_1319367		:=	1
 ENABLE_PLAT_COMPAT		:=	0
 MULTI_CONSOLE_API		:=	1
 CTX_INCLUDE_EL2_REGS		:=	0
+# When SPD=opteed is used, S-EL1 (OP-TEE) must receive Group-0 secure
+# interrupts; routing G0 to EL3 would make register_interrupt_type_handler()
+# reject INTR_TYPE_S_EL1 and panic right after OP-TEE init.
+ifeq (${SPD},opteed)
+GICV2_G0_FOR_EL3		:=	0
+else
 GICV2_G0_FOR_EL3		:=	1
+endif
 CTX_INCLUDE_AARCH32_REGS	:=	0
 
 # Do not enable SVE


### PR DESCRIPTION
When running with the OP-TEE SPD, Group-0 GIC interrupts must be routed to S-EL1 (OP-TEE) rather than EL3. Setting GICV2_G0_FOR_EL3=1 causes register_interrupt_type_handler() to reject INTR_TYPE_S_EL1 and panic immediately after OP-TEE initialisation.

Make the flag conditional on the SPD value: keep GICV2_G0_FOR_EL3=1 for other SPDs and set it to 0 when SPD=opteed.

Tested on Radxa Rock 4D (RK3576, 12 GiB LPDDR5).