### PR TITLE
feat(qti): add IPCC driver with Nord chipset support

### DIFF
--- a/drivers/qti/ipcc/ipcc.mk
+++ b/drivers/qti/ipcc/ipcc.mk
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# IPCC (Inter-Processor Communication Controller) driver, Tx trigger only
+#
+
+# Apply the block-level IPCC config (top mode, trace) ourselves, on targets
+# where no TME does it.
+QTI_IPCC_NO_TME				?= 0
+
+$(eval $(call assert_booleans,QTI_IPCC_NO_TME))
+
+$(eval $(call add_define,QTI_IPCC_ENABLED))
+$(eval $(call add_defines,QTI_IPCC_NO_TME))
+
+IPCC_DRV_PATH := drivers/qti/ipcc
+
+PLAT_INCLUDES += \
+	-I$(IPCC_DRV_PATH)				\
+	-I$(IPCC_DRV_PATH)/$(CHIPSET)			\
+	-Iinclude/drivers/qti/ipcc
+
+BL31_SOURCES += \
+	$(IPCC_DRV_PATH)/ipcc_core.c			\
+	$(IPCC_DRV_PATH)/ipcc_router.c			\
+	$(IPCC_DRV_PATH)/$(CHIPSET)/ipcc_config.c

--- a/drivers/qti/ipcc/ipcc_core.c
+++ b/drivers/qti/ipcc/ipcc_core.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <common/debug.h>
+#include <drivers/qti/ipcc/ipcc.h>
+#include <lib/mmio.h>
+
+#include "ipcc_priv.h"
+#include "ipcc_regs.h"
+
+static struct ipcc_drv_ctxt ipcc_drv_ctxt;
+
+const struct ipcc_drv_ctxt *ipcc_get_drv_ctxt(void)
+{
+	return &ipcc_drv_ctxt;
+}
+
+/*
+ * Look a client up in protocol->clients[]. The table lists only the clients the
+ * chipset instantiates on this protocol, so presence is what makes a client
+ * reachable and no separate validity flag has to be kept in sync. Returns NULL
+ * for a client the chipset does not wire here.
+ */
+static const struct ipcc_client_bsp *
+ipcc_get_client(const struct ipcc_protocol_cfg *protocol,
+		enum ipcc_client client)
+{
+	uint32_t i;
+
+	for (i = 0U; i < protocol->num_clients; i++) {
+		if (protocol->clients[i].client == client) {
+			return &protocol->clients[i];
+		}
+	}
+
+	return NULL;
+}
+
+/* Guard for every API that takes a client ID from a caller. */
+static bool ipcc_is_valid_client(const struct ipcc_protocol_cfg *protocol,
+				 enum ipcc_client client)
+{
+	return ipcc_get_client(protocol, client) != NULL;
+}
+
+/*
+ * Resolve which hardware page belongs to a client on this chip.
+ *
+ * The controller is an array of IPCC_CLIENT_STRIDE-sized pages, one per client
+ * per protocol, and addressing a client means knowing its page number -- its
+ * physical index. That is not always the client ID:
+ *
+ *   hw_mem_opt = false: pages sit at their virtual client ID positions and the
+ *   clients the chipset does not wire are holes in the span, so the physical
+ *   index is the client ID and clients[] merely says which positions are real.
+ *
+ *   hw_mem_opt = true: the holes are removed and the real clients are packed
+ *   from page 0 in the order clients[] lists them, so the physical index is the
+ *   client's row and that order is load-bearing.
+ *
+ * The result feeds two things: protocol->base for our own client (see
+ * ipcc_protocol_init()) and, from controller v3.0 on, the SEND.CLIENT_ID field
+ * for the target (see ipcc_router.c -- a separate axis).
+ *
+ * The lookup runs either way, so a client the chipset does not wire is rejected
+ * here and not only at the API boundary.
+ */
+static int ipcc_find_phys_client_idx(enum ipcc_client virt_client,
+				    const struct ipcc_protocol_cfg *protocol,
+				    uint32_t *phys_idx)
+{
+	uint32_t idx;
+
+	if ((protocol == NULL) || (phys_idx == NULL)) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Poison the output first: a caller that ignores the return code then
+	 * aims at a page that does not exist rather than at page 0, which is a
+	 * real and powered client.
+	 */
+	*phys_idx = UINT32_MAX;
+
+	/* Absence from the table is what makes a client unreachable. */
+	for (idx = 0U; idx < protocol->num_clients; idx++) {
+		if (protocol->clients[idx].client == virt_client) {
+			break;
+		}
+	}
+
+	if (idx == protocol->num_clients) {
+		VERBOSE("IPCC: invalid client %u for protocol %u\n",
+			(uint32_t)virt_client, protocol->protocol_id);
+		return -ENOTSUP;
+	}
+
+	if (ipcc_drv_ctxt.bsp->hw_mem_opt) {
+		*phys_idx = idx;
+	} else {
+		*phys_idx = (uint32_t)virt_client;
+	}
+
+	return 0;
+}
+
+static void ipcc_protocol_init(struct ipcc_protocol_cfg *protocol)
+{
+	uint32_t phys_idx = 0U;
+
+	if (protocol->phys_base == 0UL) {
+		return;
+	}
+
+#if QTI_IPCC_NO_TME
+	/*
+	 * Block-level configuration on parts where no TME applies it. Written
+	 * relative to the protocol block base, before our own client's registers
+	 * are resolved.
+	 */
+	mmio_write_32(protocol->phys_base + IPCC_TOP_MODE_BLOCK_OFF,
+		      ipcc_drv_ctxt.bsp->ipcc_mode ? IPCC_TOP_MODE_BIT : 0U);
+	mmio_write_32(protocol->phys_base + IPCC_TRACE_BLOCK_OFF,
+		      IPCC_TRACE_ENABLE_BIT);
+#endif
+
+	if (!ipcc_is_valid_client(protocol, ipcc_drv_ctxt.bsp->client) ||
+	    (ipcc_find_phys_client_idx(ipcc_drv_ctxt.bsp->client, protocol,
+				       &phys_idx) != 0)) {
+		ERROR("IPCC: protocol %u: own client %u not in config\n",
+		      protocol->protocol_id,
+		      (uint32_t)ipcc_drv_ctxt.bsp->client);
+		return;
+	}
+
+	protocol->base = protocol->phys_base +
+			 ((uintptr_t)phys_idx * IPCC_CLIENT_STRIDE) +
+			 ((uintptr_t)protocol->protocol_id * IPCC_PROTO_STRIDE);
+
+	ipcc_drv_ctxt.hw_version =
+		mmio_read_32(protocol->base + IPCC_VERSION_OFF) &
+		IPCC_VERSION_MASK;
+
+	VERBOSE("IPCC: protocol %u initialized, hw_version 0x%x\n",
+		protocol->protocol_id, ipcc_drv_ctxt.hw_version);
+}
+
+void qti_ipcc_init(void)
+{
+	uint32_t i;
+
+	ipcc_drv_ctxt.bsp = ipcc_chipset_config;
+	if (ipcc_drv_ctxt.bsp == NULL) {
+		ERROR("IPCC: no chipset config\n");
+		return;
+	}
+
+	for (i = 0U; i < ipcc_drv_ctxt.bsp->num_protocols; i++) {
+		ipcc_protocol_init(&ipcc_drv_ctxt.bsp->protocols[i]);
+	}
+
+	VERBOSE("IPCC: driver initialized, %u protocols\n",
+		ipcc_drv_ctxt.bsp->num_protocols);
+}
+
+int qti_ipcc_trigger(enum ipcc_protocol protocol, enum ipcc_client target_id,
+		     uint16_t signal_low, uint16_t signal_high)
+{
+	struct ipcc_protocol_cfg *proto;
+	const struct ipcc_client_bsp *target;
+	uint32_t phys_idx = 0U;
+	int ret;
+
+	if (ipcc_drv_ctxt.bsp == NULL) {
+		return -ENODEV;
+	}
+
+	if (signal_low > signal_high) {
+		return -EINVAL;
+	}
+
+	if ((protocol >= IPCC_PROTO_TOTAL) ||
+	    ((uint32_t)protocol >= ipcc_drv_ctxt.bsp->num_protocols)) {
+		return -EINVAL;
+	}
+
+	proto = &ipcc_drv_ctxt.bsp->protocols[protocol];
+
+	/*
+	 * Reject any client this chipset does not wire on this protocol.
+	 *
+	 * This also covers a protocol the chipset does not describe at all:
+	 * protocols[] is indexed by protocol ID and num_protocols counts its
+	 * slots, holes included, so the bound check above admits a slot left zero
+	 * by a designated initializer -- but such a slot has num_clients == 0 and
+	 * the lookup then fails for every target.
+	 */
+	target = ipcc_get_client(proto, target_id);
+	if (target == NULL) {
+		VERBOSE("IPCC: client %u not wired on protocol %u\n",
+			(uint32_t)target_id, proto->protocol_id);
+		return -ENOTSUP;
+	}
+
+	ret = ipcc_find_phys_client_idx(target_id, proto, &phys_idx);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return ipcc_tx_trigger(proto, target_id, phys_idx, signal_low,
+			       signal_high);
+}

--- a/drivers/qti/ipcc/ipcc_priv.h
+++ b/drivers/qti/ipcc/ipcc_priv.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef IPCC_PRIV_H
+#define IPCC_PRIV_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <drivers/qti/ipcc/ipcc.h>
+
+struct ipcc_client_bsp {
+	/*
+	 * A client this chipset instantiates on the protocol. Only instantiated
+	 * clients are listed, so presence here is what makes a client valid and
+	 * anything absent is rejected. When ipcc_bsp_data.hw_mem_opt is set the
+	 * array index doubles as the client's physical index and the order is
+	 * load-bearing; otherwise the array is an unordered list.
+	 */
+	enum ipcc_client client;
+};
+
+struct ipcc_protocol_cfg {
+	uint16_t protocol_id;
+	/* Signals per client on this protocol; varies by target and protocol. */
+	uint16_t num_sigs;
+	uint32_t num_clients;
+	uintptr_t phys_base;		/* protocol block base address */
+	uintptr_t base;			/* own client's registers, resolved at init */
+	struct ipcc_client_bsp *clients;
+};
+
+struct ipcc_bsp_data {
+	struct ipcc_protocol_cfg *protocols;
+	uint32_t num_protocols;
+	enum ipcc_client client;	/* this EL3's own client ID */
+#if QTI_IPCC_NO_TME
+	/*
+	 * Value programmed into IPC_CONFIG.TOP_MODE.MODE at init: true selects
+	 * the router, false the legacy block. This is a one-time block-level
+	 * setting TME owns on parts that have TME, hence the guard.
+	 */
+	bool ipcc_mode;
+#endif
+	/*
+	 * Whether the controller removes the pages of the clients this chipset
+	 * does not wire.
+	 *
+	 * True: the real clients are packed contiguously from page 0, so a
+	 * client's physical index is its position in the protocol's clients[]
+	 * array and that order is load-bearing.
+	 *
+	 * False: pages stay at their virtual client ID positions and every
+	 * unwired client is a hole in the span, so the physical index is the
+	 * virtual client ID itself and clients[] is an unordered list.
+	 *
+	 * A per-chipset hardware property, not derivable from the controller
+	 * version: parts below v3.0 ship both ways. It is also a separate axis
+	 * from what SEND.CLIENT_ID encodes, which ipcc_router.c decides at
+	 * runtime from the version register.
+	 */
+	bool hw_mem_opt;
+};
+
+struct ipcc_drv_ctxt {
+	const struct ipcc_bsp_data *bsp;
+	uint32_t hw_version;
+};
+
+/* Chipset-specific static config table, provided by <chipset>/ipcc_config.c */
+extern const struct ipcc_bsp_data *const ipcc_chipset_config;
+
+/*
+ * Only what crosses a translation unit is declared here: the context accessor
+ * ipcc_router.c reads the latched controller version from, and the trigger
+ * entry point qti_ipcc_trigger() dispatches to. The client lookup, the
+ * validity guard and the physical index resolution are static to ipcc_core.c.
+ */
+const struct ipcc_drv_ctxt *ipcc_get_drv_ctxt(void);
+
+int ipcc_tx_trigger(struct ipcc_protocol_cfg *protocol,
+		    enum ipcc_client target_id, uint32_t phys_idx,
+		    uint16_t signal_low, uint16_t signal_high);
+
+#endif /* IPCC_PRIV_H */

--- a/drivers/qti/ipcc/ipcc_regs.h
+++ b/drivers/qti/ipcc/ipcc_regs.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef IPCC_REGS_H
+#define IPCC_REGS_H
+
+#include <lib/utils_def.h>
+
+/*
+ * Register layout of the IPCC IP: offsets within a client's page and the bit
+ * fields inside them. These are common to every part the driver supports.
+ *
+ * What varies -- where the block sits, the protocol and client page strides,
+ * the signal count -- comes from <chipset>/ipcc_hwio.h, pulled in below. The
+ * #error guards keep a new target from building with a missing stride.
+ */
+#include <ipcc_hwio.h>
+
+#if !defined(IPCC_PROTO_STRIDE) || !defined(IPCC_CLIENT_STRIDE)
+#error "chipset ipcc_hwio.h must define IPCC_{PROTO,CLIENT}_STRIDE"
+#endif
+
+#define IPCC_VERSION_OFF			U(0x0)
+#define IPCC_VERSION_MASK			U(0xffffff)
+#define IPCC_VERSION_MAJOR_SHIFT		16
+#define IPCC_VERSION_MINOR_SHIFT		8
+#define IPCC_VERSION(maj, min)						\
+	((U(maj) << IPCC_VERSION_MAJOR_SHIFT) |				\
+	 (U(min) << IPCC_VERSION_MINOR_SHIFT))
+
+/*
+ * SEND is write-only: SIGNAL_ID is bits 15:0, CLIENT_ID bits 30:16 and bit 31
+ * is BROADCAST. The masks keep a bad client ID from spilling into BROADCAST.
+ */
+#define IPCC_SEND_OFF				U(0xC)
+#define IPCC_SEND_SIGNAL_ID_SHIFT		0
+#define IPCC_SEND_SIGNAL_ID_MASK		U(0xffff)
+#define IPCC_SEND_CLIENT_ID_SHIFT		16
+#define IPCC_SEND_CLIENT_ID_MASK		U(0x7fff)
+
+/*
+ * IPC_CONFIG.TOP_MODE and IPC_TRACE.ENABLE live in side-blocks outside the
+ * client pages, so their offsets are target data and only the bit positions are
+ * common. Touched only by the QTI_IPCC_NO_TME init path.
+ */
+#if QTI_IPCC_NO_TME
+#if !defined(IPCC_TOP_MODE_BLOCK_OFF) || !defined(IPCC_TRACE_BLOCK_OFF)
+#error "QTI_IPCC_NO_TME needs IPCC_{TOP_MODE,TRACE}_BLOCK_OFF in ipcc_hwio.h"
+#endif
+#endif
+
+/* IPC_CONFIG.TOP_MODE.MODE: 0 = legacy, 1 = IPC router. Reset value is 1. */
+#define IPCC_TOP_MODE_BIT			BIT_32(0)
+#define IPCC_TRACE_ENABLE_BIT			BIT_32(0)
+
+#endif /* IPCC_REGS_H */

--- a/drivers/qti/ipcc/ipcc_router.c
+++ b/drivers/qti/ipcc/ipcc_router.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <stdint.h>
+
+#include <common/debug.h>
+#include <lib/mmio.h>
+
+#include "ipcc_priv.h"
+#include "ipcc_regs.h"
+
+/*
+ * Router-mode outbound trigger: one write per signal to our own SEND register,
+ * encoding the target client and the signal. The write is a fire-and-forget
+ * doorbell, so no serialisation against other cores is required.
+ */
+int ipcc_tx_trigger(struct ipcc_protocol_cfg *protocol,
+		    enum ipcc_client target_id, uint32_t phys_idx,
+		    uint16_t signal_low, uint16_t signal_high)
+{
+	uint32_t target;
+	uint16_t sig;
+
+	if (protocol->base == 0UL) {
+		return -ENODEV;
+	}
+
+	if (signal_high >= protocol->num_sigs) {
+		return -EINVAL;
+	}
+
+	/*
+	 * From v3.0 SEND.CLIENT_ID carries the physical client index; earlier
+	 * controllers carry the virtual client ID. This is a separate axis from
+	 * hw_mem_opt -- packed parts exist that still expect the virtual ID here
+	 * -- so the version is read from the hardware, never inferred from the
+	 * table layout.
+	 */
+	if (ipcc_get_drv_ctxt()->hw_version >= IPCC_VERSION(3, 0)) {
+		target = phys_idx;
+	} else {
+		target = (uint32_t)target_id;
+	}
+
+	for (sig = signal_low; sig <= signal_high; sig++) {
+		mmio_write_32(protocol->base + IPCC_SEND_OFF,
+			      ((target & IPCC_SEND_CLIENT_ID_MASK) <<
+			       IPCC_SEND_CLIENT_ID_SHIFT) |
+			      (((uint32_t)sig & IPCC_SEND_SIGNAL_ID_MASK) <<
+			       IPCC_SEND_SIGNAL_ID_SHIFT));
+	}
+
+	VERBOSE("IPCC: triggered target %u signals [%u, %u]\n",
+		(uint32_t)target_id, signal_low, signal_high);
+
+	return 0;
+}

--- a/drivers/qti/ipcc/nord/ipcc_config.c
+++ b/drivers/qti/ipcc/nord/ipcc_config.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <drivers/qti/ipcc/ipcc.h>
+#include <lib/utils_def.h>
+
+#include <ipcc_hwio.h>
+
+#include "ipcc_priv.h"
+
+/*
+ * Nord packs its client pages: the architectural client space runs to 72, but
+ * the controller removes the pages of every client this chipset does not wire
+ * and packs the 25 that remain contiguously from page 0. A client's physical
+ * index is therefore its position in this array, not its client ID, and both
+ * the register address and the SEND register's CLIENT_ID field take that
+ * index.
+ *
+ * Order is load-bearing and must match the physical client map for MPROC --
+ * reordering silently retargets every signal.
+ *
+ * Every client is instantiated on MPROC and stays on the router.
+ */
+static struct ipcc_client_bsp mproc_clients[] = {
+	{ .client = IPCC_CLIENT_AOP,     },	/* physical index 0 */
+	{ .client = IPCC_CLIENT_APSS_S   },	/* physical index 1, us */
+	{ .client = IPCC_CLIENT_ADSP0    },
+	{ .client = IPCC_CLIENT_NSP0     },
+	{ .client = IPCC_CLIENT_NSP1     },
+	{ .client = IPCC_CLIENT_NSP2     },
+	{ .client = IPCC_CLIENT_NSP3     },
+	{ .client = IPCC_CLIENT_APSS_NS0 },
+	{ .client = IPCC_CLIENT_APSS_NS1 },
+	{ .client = IPCC_CLIENT_APSS_NS2 },
+	{ .client = IPCC_CLIENT_APSS_NS3 },
+	{ .client = IPCC_CLIENT_ADSP1    },
+	{ .client = IPCC_CLIENT_ADSP2    },
+	{ .client = IPCC_CLIENT_APSS_NS4 },
+	{ .client = IPCC_CLIENT_DUMMY    },
+	{ .client = IPCC_CLIENT_SOCCP    },
+	{ .client = IPCC_CLIENT_CPUCP    },
+	{ .client = IPCC_CLIENT_A78CSS   },
+	{ .client = IPCC_CLIENT_TMESS    },
+	{ .client = IPCC_CLIENT_SAIL0    },
+	{ .client = IPCC_CLIENT_SAIL1    },
+	{ .client = IPCC_CLIENT_SAIL2    },
+	{ .client = IPCC_CLIENT_SAIL3    },
+	{ .client = IPCC_CLIENT_SAIL4    },
+	{ .client = IPCC_CLIENT_SAIL5    },	/* physical index 24 */
+};
+
+/*
+ * Only MPROC is described. The hardware also instantiates protocols 1..4, but
+ * nothing in EL3 uses them.
+ */
+static struct ipcc_protocol_cfg protocols[] = {
+	[IPCC_PROTO_MPROC] = {
+		.protocol_id = IPCC_PROTO_MPROC,
+		.num_sigs = IPCC_MPROC_NUM_SIGS,
+		.num_clients = ARRAY_SIZE(mproc_clients),
+		.phys_base = IPCC_BASE,
+		.clients = mproc_clients,
+	},
+};
+
+static const struct ipcc_bsp_data bsp_data = {
+	.protocols = protocols,
+	.num_protocols = ARRAY_SIZE(protocols),
+	.client = IPCC_CLIENT_APSS_S,
+#if QTI_IPCC_NO_TME
+	/*
+	 * Value for IPC_CONFIG.TOP_MODE.MODE: true = router. Nord has TME to
+	 * program TOP_MODE, so QTI_IPCC_NO_TME is expected to stay 0 here and
+	 * this value to go unused.
+	 */
+	.ipcc_mode = true,
+#endif
+	.hw_mem_opt = true,
+};
+
+const struct ipcc_bsp_data *const ipcc_chipset_config = &bsp_data;

--- a/drivers/qti/ipcc/nord/ipcc_hwio.h
+++ b/drivers/qti/ipcc/nord/ipcc_hwio.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef IPCC_HWIO_H
+#define IPCC_HWIO_H
+
+#include <lib/utils_def.h>
+
+/*
+ * Target HWIO for the IPCC controller on Nord. Everything a respin or a
+ * different SoC can change lives here: block address, block geometry and the
+ * per-protocol signal count. The register offsets and bit fields, which the IP
+ * keeps common across parts, are in drivers/qti/ipcc/ipcc_regs.h.
+ *
+ * The block holds the core pages at 0x09000000, the config block at 0x093c0000
+ * and the trace block at 0x093c1000. The window must be covered by the
+ * platform's device mapping before qti_ipcc_init() runs.
+ */
+#define IPCC_BASE			UL(0x09000000)
+#define IPCC_SIZE			UL(0x00400000)
+
+/*
+ * Core geometry: 5 protocol blocks of 0xc0000 (72 clients 0x1000 apart), so a
+ * register lives at
+ *
+ *   IPCC_BASE + off + IPCC_PROTO_STRIDE * protocol_id +
+ *		       IPCC_CLIENT_STRIDE * phys_idx
+ *
+ * The protocol block grows with the client count, which is why the stride is
+ * per-target and not shared.
+ */
+#define IPCC_PROTO_STRIDE		U(0xc0000)
+#define IPCC_CLIENT_STRIDE		U(0x1000)
+
+/*
+ * Signals per client, per protocol. Not a property of the IP -- it varies by
+ * target and by protocol -- so each protocol the config describes needs its own
+ * count here.
+ */
+#define IPCC_MPROC_NUM_SIGS		U(8)
+
+/*
+ * TOP_MODE and TRACE block offsets from IPCC_BASE. Here they do land
+ * immediately past the five protocol blocks, but they are target data rather
+ * than something to compute.
+ */
+#define IPCC_TOP_MODE_BLOCK_OFF		U(0x3c0000)
+#define IPCC_TRACE_BLOCK_OFF		U(0x3c1000)
+
+#endif /* IPCC_HWIO_H */

--- a/include/drivers/qti/ipcc/ipcc.h
+++ b/include/drivers/qti/ipcc/ipcc.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef QTI_IPCC_H
+#define QTI_IPCC_H
+
+#include <stdint.h>
+
+/*
+ * IPCC (Inter-Processor Communication Controller) host interface.
+ *
+ * Outbound only: BL31 raises signals towards other subsystems and never
+ * receives them, so there is no signal registration, interrupt handling or
+ * callback support. Both delivery mechanisms are implemented and the chipset
+ * config picks between them per client:
+ *
+ *   - Router: one write to our own SEND register encodes target and signal.
+ *   - Legacy: each target client owns a trigger register and each signal a
+ *     fixed bit mask within it.
+ */
+
+/* Protocols the controller defines; a chipset instantiates a subset. */
+enum ipcc_protocol {
+	IPCC_PROTO_MPROC = 0,
+	IPCC_PROTO_COMPUTEL0 = 1,
+	IPCC_PROTO_COMPUTEL1 = 2,
+	IPCC_PROTO_PERIPH = 3,
+	IPCC_PROTO_FENCE = 4,
+
+	IPCC_PROTO_TOTAL,
+};
+
+/*
+ * Client IDs the controller defines. They are architectural -- remote
+ * subsystems agree on them -- so every value is spelled out and none is ever
+ * renumbered. The space is sparse (65, 72..83 and 85..127 are unassigned),
+ * which makes IPCC_CLIENT_TOTAL one past the highest ID, not a client count.
+ */
+enum ipcc_client {
+	IPCC_CLIENT_AOP = 0,
+	IPCC_CLIENT_TZ = 1,
+	IPCC_CLIENT_MPSS = 2,
+	IPCC_CLIENT_LPASS = 3,
+	IPCC_CLIENT_SLPI = 4,
+	IPCC_CLIENT_SDC = 5,
+	IPCC_CLIENT_NSP0 = 6,
+	IPCC_CLIENT_NPU = 7,
+	IPCC_CLIENT_APPS = 8,
+	IPCC_CLIENT_GPU = 9,
+	IPCC_CLIENT_CVP = 10,
+	IPCC_CLIENT_CAM = 11,
+	IPCC_CLIENT_VPU = 12,
+	IPCC_CLIENT_PCIE0 = 13,
+	IPCC_CLIENT_PCIE1 = 14,
+	IPCC_CLIENT_PCIE2 = 15,
+	IPCC_CLIENT_SPSS = 16,
+	IPCC_CLIENT_SMSS = 17,
+	IPCC_CLIENT_NSP1 = 18,
+	IPCC_CLIENT_PCIE3 = 19,
+	IPCC_CLIENT_PCIE4 = 20,
+	IPCC_CLIENT_PCIE5 = 21,
+	IPCC_CLIENT_PCIE6 = 22,
+	IPCC_CLIENT_TMESS = 23,
+	IPCC_CLIENT_WPSS = 24,
+	IPCC_CLIENT_DPU = 25,
+	IPCC_CLIENT_IPA = 26,
+	IPCC_CLIENT_SAIL0 = 27,
+	IPCC_CLIENT_SAIL1 = 28,
+	IPCC_CLIENT_SAIL2 = 29,
+	IPCC_CLIENT_SAIL3 = 30,
+	IPCC_CLIENT_GPDSP0 = 31,
+	IPCC_CLIENT_GPDSP1 = 32,
+	IPCC_CLIENT_APSS_NS1 = 33,
+	IPCC_CLIENT_APSS_NS2 = 34,
+	IPCC_CLIENT_APSS_NS3 = 35,
+	IPCC_CLIENT_APSS_NS4 = 36,
+	IPCC_CLIENT_APSS_NS5 = 37,
+	IPCC_CLIENT_APSS_NS6 = 38,
+	IPCC_CLIENT_APSS_NS7 = 39,
+	IPCC_CLIENT_TENX = 40,
+	IPCC_CLIENT_ORAN = 41,
+	IPCC_CLIENT_MVMSS = 42,
+	IPCC_CLIENT_DPU1 = 43,
+	IPCC_CLIENT_PCIE7 = 44,
+	IPCC_CLIENT_DBG = 45,
+	IPCC_CLIENT_SOCCP = 46,
+	IPCC_CLIENT_ICP1 = 47,
+	IPCC_CLIENT_NSP2 = 48,
+	IPCC_CLIENT_NSP3 = 49,
+	IPCC_CLIENT_SAIL4 = 50,
+	IPCC_CLIENT_SAIL5 = 51,
+	IPCC_CLIENT_CPUCP = 52,
+	IPCC_CLIENT_A78CSS = 53,
+	IPCC_CLIENT_GPU1 = 54,
+	IPCC_CLIENT_OOBSS = 55,
+	IPCC_CLIENT_OOBSS_S = 56,
+	IPCC_CLIENT_DCP = 57,
+	IPCC_CLIENT_PDP0 = 58,
+	IPCC_CLIENT_PDP1 = 59,
+	IPCC_CLIENT_PDP2 = 60,
+	IPCC_CLIENT_PDP3 = 61,
+	IPCC_CLIENT_M55_WM = 62,
+	IPCC_CLIENT_LSR = 63,
+	IPCC_CLIENT_QECP = 64,
+	IPCC_CLIENT_QUP_TOP0 = 66,
+	IPCC_CLIENT_QUP_TOP1 = 67,
+	IPCC_CLIENT_QUP_TOP2 = 68,
+	IPCC_CLIENT_QUP_TOP3 = 69,
+	IPCC_CLIENT_QUP_SSC0 = 70,
+	IPCC_CLIENT_QUP_SSC1 = 71,
+	IPCC_CLIENT_QUP_TOP4 = 84,
+	IPCC_CLIENT_IFE0 = 128,
+	IPCC_CLIENT_IFE1 = 129,
+	IPCC_CLIENT_IFE2 = 130,
+	IPCC_CLIENT_IFE3 = 131,
+	IPCC_CLIENT_IFE4 = 132,
+	IPCC_CLIENT_IFE5 = 133,
+	IPCC_CLIENT_IFE6 = 134,
+	IPCC_CLIENT_IFE7 = 135,
+	IPCC_CLIENT_IFE8 = 136,
+	IPCC_CLIENT_IFE9 = 137,
+	IPCC_CLIENT_IFE10 = 138,
+	IPCC_CLIENT_IFE11 = 139,
+	IPCC_CLIENT_IFE12 = 140,
+
+	IPCC_CLIENT_TOTAL,
+
+	/* Alternate names for the same clients; both spellings are in use. */
+	IPCC_CLIENT_RPM = IPCC_CLIENT_AOP,
+	IPCC_CLIENT_APSS_S = IPCC_CLIENT_TZ,
+	IPCC_CLIENT_ADSP0 = IPCC_CLIENT_LPASS,
+	IPCC_CLIENT_CDSP = IPCC_CLIENT_NSP0,
+	IPCC_CLIENT_APSS_NS0 = IPCC_CLIENT_APPS,
+	IPCC_CLIENT_GPU0 = IPCC_CLIENT_GPU,
+	IPCC_CLIENT_ICP0 = IPCC_CLIENT_CAM,
+	IPCC_CLIENT_DPU0 = IPCC_CLIENT_DPU,
+	IPCC_CLIENT_ADSP1 = IPCC_CLIENT_GPDSP0,
+	IPCC_CLIENT_ADSP2 = IPCC_CLIENT_GPDSP1,
+	IPCC_CLIENT_DUMMY = IPCC_CLIENT_DBG,
+	IPCC_CLIENT_APCP = IPCC_CLIENT_CPUCP,
+	IPCC_CLIENT_PRIME_CORE = IPCC_CLIENT_M55_WM,
+	IPCC_CLIENT_LMCU = IPCC_CLIENT_M55_WM,
+	IPCC_CLIENT_M55_AM = IPCC_CLIENT_LSR,
+	IPCC_CLIENT_CAM_ENG0 = IPCC_CLIENT_IFE0,
+	IPCC_CLIENT_CAM_ENG1 = IPCC_CLIENT_IFE1,
+	IPCC_CLIENT_CAM_ENG2 = IPCC_CLIENT_IFE2,
+	IPCC_CLIENT_CAM_ENG3 = IPCC_CLIENT_IFE3,
+	IPCC_CLIENT_CAM_ENG4 = IPCC_CLIENT_IFE4,
+	IPCC_CLIENT_CAM_ENG5 = IPCC_CLIENT_IFE5,
+	IPCC_CLIENT_CAM_ENG6 = IPCC_CLIENT_IFE6,
+	IPCC_CLIENT_CAM_ENG7 = IPCC_CLIENT_IFE7,
+	IPCC_CLIENT_CAM_ENG8 = IPCC_CLIENT_IFE8,
+	IPCC_CLIENT_CAM_ENG9 = IPCC_CLIENT_IFE9,
+	IPCC_CLIENT_CAM_ENG10 = IPCC_CLIENT_IFE10,
+	IPCC_CLIENT_CAM_ENG11 = IPCC_CLIENT_IFE11,
+	IPCC_CLIENT_CAM_ENG12 = IPCC_CLIENT_IFE12,
+};
+
+#ifdef QTI_IPCC_ENABLED
+
+/*
+ * Resolve our own per-protocol register addresses from the chipset config and
+ * latch the controller version. Call once, before any trigger.
+ */
+void qti_ipcc_init(void);
+
+/*
+ * Trigger the signal range [signal_low, signal_high] towards target_id on the
+ * given protocol, over whichever mechanism the chipset config wires for that
+ * target. Returns 0 on success or a negative errno.
+ */
+int qti_ipcc_trigger(enum ipcc_protocol protocol, enum ipcc_client target_id,
+		     uint16_t signal_low, uint16_t signal_high);
+
+#else /* !QTI_IPCC_ENABLED */
+
+static inline void qti_ipcc_init(void) {}
+
+static inline int qti_ipcc_trigger(enum ipcc_protocol protocol,
+				   enum ipcc_client target_id,
+				   uint16_t signal_low, uint16_t signal_high)
+{
+	return 0;
+}
+
+#endif /* QTI_IPCC_ENABLED */
+
+#endif /* QTI_IPCC_H */

--- a/plat/qti/common/src/qti_bl31_setup.c
+++ b/plat/qti/common/src/qti_bl31_setup.c
@@ -15,6 +15,7 @@
 #include <drivers/qti/accesscontrol/accesscontrol.h>
 #include <drivers/qti/accesscontrol/xpu.h>
 #include <drivers/qti/chipinfo/chipinfo.h>
+#include <drivers/qti/ipcc/ipcc.h>
 #include <drivers/qti/pdc/pdc.h>
 #include <drivers/qti/pwr_utils/pwr_utils.h>
 #include <drivers/qti/qtimer/qtimer.h>
@@ -98,6 +99,7 @@ void bl31_platform_setup(void)
 	plat_qti_gic_init();
 	qti_pdc_init();
 	qti_pwr_utils_init();
+	qti_ipcc_init();
 
 	if (qti_chipinfo_init() != CHIPINFO_SUCCESS) {
 		WARN("ChipInfo initialization error\n");


### PR DESCRIPTION
## Summary

Adds the IPCC (Inter-Processor Communication Controller) router driver
for BL31, used to raise signals to other subsystems, with Nord's
chipset-specific client configuration.

- `drivers/qti/ipcc/`: generic router-mode driver core, shared
  register definitions, and build glue (`ipcc.mk`)
- `drivers/qti/ipcc/nord/`: Nord's packed client table and HWIO
  (block base/geometry, per-protocol signal count)
- `include/drivers/qti/ipcc/ipcc.h`: public API — `qti_ipcc_init()` /
  `qti_ipcc_trigger()` — plus the protocol and client ID enums

Nord packs its client pages contiguously from page 0, so a client's
physical index is its position in the config table rather than its
architectural client ID. This mapping (`hw_mem_opt`) is resolved at
init in `ipcc_core.c`.

## Test plan

- [ ] Build BL31 for a Nord-based platform with `CHIPSET=nord`
- [ ] Confirm `qti_ipcc_init()` resolves each protocol's base address
      and latches `hw_version`
- [ ] Confirm `qti_ipcc_trigger()` reaches the SEND register for a
      wired client and returns an error for an unwired one
