### PR TITLE
fix(coreboot): validate entry size before unsigned subtraction in coreboot_table_setup()

### DIFF
--- a/lib/coreboot/coreboot_table.c
+++ b/lib/coreboot/coreboot_table.c
@@ -141,6 +141,10 @@ void coreboot_table_setup(void *base)
 
 		switch (read_le32(&entry->tag)) {
 		case CB_TAG_MEMORY:
+			if (read_le32(&entry->size) < offsetof(cb_entry_t, memranges)) {
+				ERROR("coreboot memory entry too small!\n");
+				break;
+			}
 			size = read_le32(&entry->size) -
 			       offsetof(cb_entry_t, memranges);
 			if (size > sizeof(coreboot_memranges)) {


### PR DESCRIPTION
Fixes #176 (TrustedFirmware-A/trusted-firmware-a#176)

**Problem:**
coreboot_table_setup() computes:

    size = read_le32(&entry->size) - offsetof(cb_entry_t, memranges);

without first validating that entry->size is large enough. If
entry->size < offsetof(cb_entry_t, memranges) (8 bytes), unsigned
subtraction underflows, producing a value near SIZE_MAX which gets
clamped to sizeof(coreboot_memranges) (640 bytes), causing a
640-byte read past the record boundary.

**Fix:**
Add an explicit minimum-size check before the subtraction, mirroring
the validation pattern already used in the Transfer List parser
(contrib/libtl/src/generic/transfer_list.c).

**Scope:**
Only affects builds with COREBOOT=1 (disabled by default).
Reported as a defense-in-depth hardening gap consistent with
validation already applied elsewhere in the codebase.